### PR TITLE
[firebase][cloudmessaging] Fix typos

### DIFF
--- a/Firebase.CloudMessaging/component/GettingStarted.md
+++ b/Firebase.CloudMessaging/component/GettingStarted.md
@@ -73,7 +73,7 @@ public override void DidEnterBackground (UIApplication application)
 	// Use this method to release shared resources, save user data, invalidate timers and store the application state.
 	// If your application supports background exection this method is called instead of WillTerminate when the user quits.
 	Messaging.SharedInstance.Disconnect ();
-	Console.WriteLine ("Disconnected from FMC");
+	Console.WriteLine ("Disconnected from FCM");
 }
 ```
 

--- a/Firebase.CloudMessaging/samples/CloudMessagingSample/CloudMessagingSample/AppDelegate.cs
+++ b/Firebase.CloudMessaging/samples/CloudMessagingSample/CloudMessagingSample/AppDelegate.cs
@@ -47,7 +47,7 @@ namespace CloudMessagingSample
 			// Use this method to release shared resources, save user data, invalidate timers and store the application state.
 			// If your application supports background exection this method is called instead of WillTerminate when the user quits.
 			Messaging.SharedInstance.Disconnect ();
-			Console.WriteLine ("Disconnected from FMC");
+			Console.WriteLine ("Disconnected from FCM");
 		}
 
 		public override void DidReceiveRemoteNotification (UIApplication application, NSDictionary userInfo, Action<UIBackgroundFetchResult> completionHandler)


### PR DESCRIPTION
Fixed typos on Firebase Cloud Messaging
example)
* FMC -> FCM